### PR TITLE
Fix for column names with Capital letters

### DIFF
--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -67,7 +67,7 @@ const GoogleSheet = function (sheetReference, sheetName) {
                 if (!sheetName) {
                     sheetName = tabletop.foundSheetNames[0];
                 }
-                var columnNames = tabletop.sheets(sheetName).column_names;
+                var columnNames = tabletop.sheets(sheetName).columnNames;
 
                 var contentValidator = new ContentValidator(columnNames);
                 contentValidator.verifyContent();

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -60,12 +60,12 @@ const GoogleSheet = function (sheetReference, sheetName) {
                 .html(message);
         }
 
-        function createRadar(sheets, tabletop) {
+        function createRadar(__, tabletop) {
 
             try {
 
                 if (!sheetName) {
-                    sheetName = Object.keys(sheets)[0];
+                    sheetName = tabletop.foundSheetNames[0];
                 }
                 var columnNames = tabletop.sheets(sheetName).column_names;
 


### PR DESCRIPTION
Fix for #11 

When using column_names isNew is return as isnew so the comparison is the validation fails. columnNames returns the proper names (i.e. isNew). 

You can use following spreadsheet to test it. 

https://docs.google.com/spreadsheets/d/1waDG0_W3-yNiAaUfxcZhTKvl7AUCgXwQw8mdPjCz86U/edit#gid=0