### PR TITLE
Option to set sheet via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The app uses [Tabletop.js](https://github.com/jsoma/tabletop) to fetch the data 
 
 The application uses [webpack](https://webpack.github.io/) to package dependencies and minify all .js and .scss files.
 
+Bypass the URL prompt by supplying environment variables `RADAR_SHEET_ID` and `RADAR_SHEET_NAME` during the build. 
+
 ## Contribute
 
 All tasks are defined in `package.json`.

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -155,7 +155,15 @@ const GoogleSheetInput = function () {
     var self = {};
 
     self.build = function () {
-        var queryParams = QueryParams(window.location.search.substring(1));
+        var queryParams;
+        if (process.env.RADAR_SHEET_ID) {
+          queryParams = {
+            'sheetId':   process.env.RADAR_SHEET_ID,
+            'sheetName': process.env.RADAR_SHEET_NAME
+          };
+        } else {
+          queryParams = QueryParams(window.location.search.substring(1));
+        }
 
         if (queryParams.sheetId) {
             var sheet = GoogleSheet(queryParams.sheetId, queryParams.sheetName);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,11 @@ let plugins = [
         template: './src/index.html',
         inject: 'body',
         chunks: 'app'
-    })
+    }),
+    new webpack.EnvironmentPlugin([
+        'RADAR_SHEET_ID',
+        'RADAR_SHEET_NAME'
+    ])
 ];
 
 if (isProd) {


### PR DESCRIPTION
Here's a small tweak that allows optional environment variables `RADAR_SHEET_ID` and `RADAR_SHEET_NAME` during build to bypass the prompt for a URL (i.e., to deploy a specific radar rather than prompting for one or hardcoding the sheet). If the environment variable are not specified, the user is prompted for a URL.
