### PR TITLE
BYOR Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# See https://help.github.com/ignore-files/ for more about ignoring files.
+
+# dependencies
+node_modules
+
+# testing
+coverage
+
+# production
+build
+dist
+
+# misc
+.DS_Store
+
+npm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:7.10.1 as source
+WORKDIR /src/build-your-own-radar
+COPY package.json ./
+RUN npm install
+COPY . ./
+RUN npm run build
+
+FROM nginx:1.13.5
+WORKDIR /opt/build-your-own-radar
+COPY --from=source /src/build-your-own-radar/dist .
+COPY default.template /etc/nginx/conf.d/default.template
+CMD /bin/bash -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"

--- a/default.template
+++ b/default.template
@@ -1,0 +1,28 @@
+# default server block to handle undefined domain names
+server {
+  listen 80 default_server;
+  server_name _;
+  return 403;
+}
+
+# server block for static file serving
+server {
+  listen 80;
+  server_name ${SERVER_NAMES};
+  location / {
+    root /opt/build-your-own-radar;
+    index index.html;
+  }
+
+  # custom error page for 404 errors
+  error_page 404 /error.html;
+  location = /error.html {
+    root /opt/build-your-own-radar;
+  }
+
+  # nginx default error page for 50x errors
+  error_page 500 502 503 504 /50x.html;
+  location = /50x.html {
+    root /usr/share/nginx/html;
+  }
+}


### PR DESCRIPTION
This PR helps to release BYOR as a Docker image for users. This image can be easily hosted by users without having to set up the repo and generate the static content. All they have to do is pull the image from a central Docker repository like [Docker Hub](https://hub.docker.com/) and run it.

[Dockerfile](https://github.com/arunvelsriram/build-your-own-radar/blob/e5d6eecdc1133f11c253134646eef12b57b00097/Dockerfile) builds an image containing the static website content and nginx. When the image is run it serves the static content via nginx.

### Extra features

Following things are handled by the image itself:

- Injecting nginx `server_name` through an environment variable (described in the example section)
- Blocking undefined domain names from serving content
- Serving custom error page for 404 errors

**Note:** 50x errors are routed to default nginx error page and this can be customized if needed.

### Example 

I have pushed an image to [my Docker Hub repo](https://hub.docker.com/r/arunvelsriram/byor/). To run this image:

```
$ docker pull arunvelsriram/byor
$ docker run --rm -p 8080:80 -e SERVER_NAMES="localhost 127.0.0.1" arunvelsriram/byor
$ open http://localhost:8080
```

The environment variable `SERVER_NAMES` is used to pass the valid domain names to nginx. For example, if you want to serve through your domains *example-radar.com* and *www.example-radar.com* then use: `SERVER_NAMES="example-radar.com www.example-radar.com"`.

Similarly, you can make Docker images available through ThoughtWorks organization Docker Hub repo. In the example image, I have used Docker's default *latest* tag. You might have to use proper tags based on image version.

Cheers,
Arun