### PR TITLE
Move to Alpine + Tini to handle SIGINT correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ COPY . ./
 RUN npm run build
 
 FROM nginx:1.13.8-alpine
-RUN apk add --update --no-cache tini
-ENTRYPOINT ["tini", "-g", "--"]
+ADD https://github.com/jwilder/dockerize/releases/download/v0.6.0/dockerize-alpine-linux-amd64-v0.6.0.tar.gz dockerize.tar.gz
+RUN tar xf dockerize.tar.gz -C /usr/local/bin \
+  && rm dockerize.tar.gz
 WORKDIR /opt/build-your-own-radar
 COPY --from=source /src/build-your-own-radar/dist .
-COPY default.template /etc/nginx/conf.d/default.template
-CMD /bin/sh -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+COPY default.tmpl /etc/nginx/conf.d/default.tmpl
+ENTRYPOINT ["dockerize", "-template", "/etc/nginx/conf.d/default.tmpl:/etc/nginx/conf.d/default.conf"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,10 @@ RUN npm install
 COPY . ./
 RUN npm run build
 
-FROM nginx:1.13.5
+FROM nginx:1.13.8-alpine
+RUN apk add --update --no-cache tini
+ENTRYPOINT ["tini", "-g", "--"]
 WORKDIR /opt/build-your-own-radar
 COPY --from=source /src/build-your-own-radar/dist .
 COPY default.template /etc/nginx/conf.d/default.template
-CMD /bin/bash -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
+CMD /bin/sh -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"

--- a/default.tmpl
+++ b/default.tmpl
@@ -8,7 +8,7 @@ server {
 # server block for static file serving
 server {
   listen 80;
-  server_name ${SERVER_NAMES};
+  server_name {{ .Env.SERVER_NAMES }};
   location / {
     root /opt/build-your-own-radar;
     index index.html;

--- a/default.tmpl
+++ b/default.tmpl
@@ -8,7 +8,7 @@ server {
 # server block for static file serving
 server {
   listen 80;
-  server_name {{ .Env.SERVER_NAMES }};
+  server_name {{ default .Env.SERVER_NAMES "localhost" }};
   location / {
     root /opt/build-your-own-radar;
     index index.html;


### PR DESCRIPTION
The Docker image currently uses

```dockerfile
CMD /bin/sh -c "envsubst < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
```

This allows the `server` block to be dynamically configured at runtime which is great. However `bash` doesn't forward signals to the children properly, which means Ctrl-C doesn't stop the container as expected.

Adding [tini](https://github.com/krallin/tini) as the `ENTRYPOINT` restores the expected behaviour for SIGINT. This PR also switches to Alpine linux where `tini` is available out of the box. This also makes the final Docker image 20MB instead of 110MB.
