### PR TITLE
Allow Accessing Other Sheets From Linked Spreadsheet 

### DIFF
--- a/spec/models/radar-spec.js
+++ b/spec/models/radar-spec.js
@@ -137,6 +137,20 @@ describe('Radar', function () {
     });
   });
 
+  describe('alternatives', function() {
+    it('returns a provided alternatives', function() {
+      var radar = new Radar();
+
+      var alternative1 = 'alternative1';
+      var alternative2 = 'alternative2';
+
+      radar.addAlternative(alternative1);
+      radar.addAlternative(alternative2);
+
+      expect(radar.getAlternatives()).toEqual([alternative1, alternative2]);
+    });
+  });
+
   describe('rings', function () {
     var quadrant, radar, firstRing, secondRing, otherQuadrant;
 

--- a/spec/util/queryParamProcessor-spec.js
+++ b/spec/util/queryParamProcessor-spec.js
@@ -1,0 +1,23 @@
+const QueryParams = require('../../src/util/queryParamProcessor');
+
+describe('QueryParams', function () {
+
+    it('retrieves one parameter', function () {
+        var params = QueryParams('param1=value1');
+
+        expect(params.param1).toEqual('value1');
+    });
+
+    it('retrieves zero parameter', function () {
+        var params = QueryParams('');
+
+        expect(params).toEqual({});
+    });
+
+    it('retrieves one parameter', function () {
+        var params = QueryParams('param1=value1&param2=value2');
+
+        expect(params.param1).toEqual('value1');
+        expect(params.param2).toEqual('value2');
+    });
+});

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -4,6 +4,7 @@ const Chance = require('chance');
 const _ = require('lodash/core');
 
 const RingCalculator = require('../util/ringCalculator');
+const QueryParams = require('../util/queryParamProcessor');
 
 const MIN_BLIP_WIDTH = 12;
 
@@ -529,11 +530,33 @@ const Radar = function (size, radar) {
     return self;
   };
 
+  function plotAlternativeRadars(alternatives, currentSheet) {
+    var alternativeDiv = d3.select('body')
+      .insert('div', '#radar-plot + *')
+      .attr('id', 'alternative-buttons');
+
+    alternatives.forEach(function(alternative) {
+      if (alternative !== currentSheet) {
+        alternativeDiv
+        .append('div')
+          .attr('class', 'button first full-view alternative')
+          .text(alternative)
+          .on('click', function(){
+            var noParamUrl = window.location.href.substring(0,window.location.href.indexOf(window.location.search));
+            var queryParams = QueryParams(window.location.search.substring(1));
+            window.location = noParamUrl + '?sheetId=' + queryParams.sheetId + '&sheetName=' + encodeURIComponent(alternative);
+          });
+      }
+    });
+  }
+
   self.plot = function () {
-    var rings, quadrants;
+    var rings, quadrants, alternatives, currentSheet;
 
     rings = radar.rings();
     quadrants = radar.quadrants();
+    alternatives = radar.getAlternatives();
+    currentSheet = radar.getCurrentSheet();
     var header = plotRadarHeader();
 
     plotQuadrantButtons(quadrants, header);
@@ -549,6 +572,7 @@ const Radar = function (size, radar) {
       plotBlips(quadrantGroup, rings, quadrant);
     });
 
+    plotAlternativeRadars(alternatives, currentSheet);
     plotRadarFooter();
   };
 

--- a/src/models/radar.js
+++ b/src/models/radar.js
@@ -18,12 +18,30 @@ const Radar = function() {
     {order: 'third', startAngle: -90},
     {order: 'fourth', startAngle: -180}
   ];
+  alternatives = [];
+  currentSheetName = "";
   self = {};
 
   function setNumbers(blips) {
     blips.forEach(function (blip) {
       blip.setNumber(++blipNumber);
     });
+  }
+
+  self.addAlternative = function (sheetName) {
+    alternatives.push(sheetName);
+  }
+
+  self.getAlternatives = function () {
+    return alternatives;
+  }
+
+  self.setCurrentSheet = function (sheetName) {
+    currentSheetName = sheetName;
+  }
+
+  self.getCurrentSheet = function () {
+    return currentSheetName;
   }
 
   self.addQuadrant = function (quadrant) {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -36,6 +36,10 @@ body {
     display: none;
   }
 
+  #alternative-buttons {
+    display: none;
+  }
+
   .quadrant-table {
     .quadrant-table__name {
       display: block;
@@ -150,6 +154,18 @@ body {
 
 
 @media screen {
+
+  .button {
+
+    &.alternative {
+      margin-top: 20px;
+    }
+
+  }
+
+  #alternative-buttons {
+    text-align: center;
+  }
 
   #radar {
     width: 80%;

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -13,13 +13,14 @@ const Quadrant = require('../models/quadrant');
 const Ring = require('../models/ring');
 const Blip = require('../models/blip');
 const GraphingRadar = require('../graphing/radar');
+const QueryParams = require('./queryParamProcessor');
 const MalformedDataError = require('../exceptions/malformedDataError');
 const SheetNotFoundError = require('../exceptions/sheetNotFoundError');
 const ContentValidator = require('./contentValidator');
 const Sheet = require('./sheet');
 const ExceptionMessages = require('./exceptionMessages');
 
-const plotRadar = function (title, blips) {
+const plotRadar = function (title, blips, currentRadarName, alternativeRadars) {
     document.title = title;
     d3.selectAll(".loading").remove();
 
@@ -46,6 +47,16 @@ const plotRadar = function (title, blips) {
     _.each(quadrants, function (quadrant) {
         radar.addQuadrant(quadrant)
     });
+
+    if(alternativeRadars != undefined || true) {
+        alternativeRadars.forEach(function(sheetName) {
+            radar.addAlternative(sheetName);
+        });
+    }
+    
+    if(currentRadarName != undefined || true) {
+        radar.setCurrentSheet(currentRadarName);
+    }
 
     var size = (window.innerHeight - 133) < 620 ? 620 : window.innerHeight - 133;
 
@@ -85,7 +96,7 @@ const GoogleSheet = function (sheetReference, sheetName) {
                 var all = tabletop.sheets(sheetName).all();
                 var blips = _.map(all, new InputSanitizer().sanitize);
 
-                plotRadar(tabletop.googleSheetName, blips);
+                plotRadar(tabletop.googleSheetName + ' - ' + sheetName, blips, sheetName, tabletop.foundSheetNames);
             } catch (exception) {
                 plotErrorMessage(exception);
             }
@@ -115,7 +126,7 @@ const CSVDocument = function (url) {
             contentValidator.verifyContent();
             contentValidator.verifyHeaders();
             var blips = _.map(data, new InputSanitizer().sanitize);
-            plotRadar(FileName(url), blips);
+            plotRadar(FileName(url), blips, "CSV File", []);
         } catch (exception) {
             plotErrorMessage(exception);
         }
@@ -127,21 +138,6 @@ const CSVDocument = function (url) {
     };
 
     return self;
-};
-
-const QueryParams = function (queryString) {
-    var decode = function (s) {
-        return decodeURIComponent(s.replace(/\+/g, " "));
-    };
-
-    var search = /([^&=]+)=?([^&]*)/g;
-
-    var queryParams = {};
-    var match;
-    while (match = search.exec(queryString))
-        queryParams[decode(match[1])] = decode(match[2]);
-
-    return queryParams
 };
 
 const DomainName = function (url) {

--- a/src/util/queryParamProcessor.js
+++ b/src/util/queryParamProcessor.js
@@ -1,0 +1,16 @@
+const QueryParams = function (queryString) {
+    var decode = function (s) {
+        return decodeURIComponent(s.replace(/\+/g, " "));
+    };
+
+    var search = /([^&=]+)=?([^&]*)/g;
+
+    var queryParams = {};
+    var match;
+    while (match = search.exec(queryString))
+        queryParams[decode(match[1])] = decode(match[2]);
+
+    return queryParams
+};
+
+module.exports = QueryParams;


### PR DESCRIPTION
Allows the ability to access the other sheets in the spreadsheet from the UI. Every sheet in the linked spreadsheet will be shown as a button at the bottom of the radar (except the currently viewed sheet).

Example use case: Having one spreadsheet for all your tech radars separated by sheets. Separations could be for different departments, projects, quarters of a year, etc. 