### PR TITLE
fix: skip plot AlternativeRadars elements for csv case

### DIFF
--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -619,7 +619,9 @@ const Radar = function (size, radar) {
     currentSheet = radar.getCurrentSheet()
     var header = plotRadarHeader()
 
-    plotAlternativeRadars(alternatives, currentSheet)
+    if (alternatives.length) {
+      plotAlternativeRadars(alternatives, currentSheet)
+    }
 
     plotQuadrantButtons(quadrants, header)
 


### PR DESCRIPTION
Skip plot AlternativeRadars elements for CSV case. The block with texts: 
```html
Choose a sheet to populate radar
Build your Technology Radar
```
 won't be rendered.
