### PR TITLE
[Sidharth/Devansh] Revert docker image to run on nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,12 @@ WORKDIR /src/build-your-own-radar
 COPY package.json ./
 RUN npm install
 COPY . ./
-CMD ["npm","run","dev"]
+RUN npm run build
+
+FROM nginx:1.15.9
+WORKDIR /opt/build-your-own-radar
+COPY --from=source /src/build-your-own-radar/dist .
+COPY --from=source /src/build-your-own-radar/start_nginx.sh .
+COPY default.template /etc/nginx/conf.d/default.conf
+
+CMD ./start_nginx.sh

--- a/src/util/googleAuth.js
+++ b/src/util/googleAuth.js
@@ -2,8 +2,8 @@
 const d3 = require('d3')
 
 // Client ID and API key from the Developer Console
-var CLIENT_ID = process.env.CLIENT_ID
-var API_KEY = process.env.API_KEY
+var CLIENT_ID = process.env.CLIENT_ID || ''
+var API_KEY = process.env.API_KEY || ''
 
 // Array of API discovery doc URLs for APIs used by the quickstart
 var DISCOVERY_DOCS = ['https://sheets.googleapis.com/$discovery/rest?version=v4']

--- a/start_nginx.sh
+++ b/start_nginx.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Regex for updating API_KEY and CLIENT_ID values in compiled js file. Code snippet from googleAuth.js initClient function.
+if [[ $API_KEY ]]; then
+    sed -i -e "s/\(gapi.client.init({apiKey:\)\"[^\"]*\"/\1\"$API_KEY\"/g" main.*.js
+else
+    sed -i -e "s/\(gapi.client.init({apiKey:\)\"[^\"]*\"/\1\"\"/g" main.*.js
+fi
+
+if [[ $CLIENT_ID ]]; then
+    sed -i -e "s/\(gapi.client.init({apiKey:\"[^\"]*\",clientId:\)\"[^\"]*\"/\1\"$CLIENT_ID\"/g" main.*.js
+else
+    sed -i -e "s/\(gapi.client.init({apiKey:\"[^\"]*\",clientId:\)\"[^\"]*\"/\1\"\"/g" main.*.js
+fi
+
+nginx -g 'daemon off;'


### PR DESCRIPTION
Hosting as docker needs at the least client id to use google sheets (API key as well in case of private sheets).
While running as docker image, we need to pass the client id and API Key as environment variables (and still manage to start the server as production).
The change includes a new script to start nginx server and replace the client id and/or API key in the compiled code during run time. This can avoid hardcode of the creds during the compilation.

**What this change is:**
- New script _start_nginx.sh_ that will substitute the API key and CLIENT iD if provided, then start the nginx server
- The docker file is configured to invoke this script instead of directly starting the nginx server
- The script uses regex to identify the position of api key and client id to substitute the appropriate values.
- The docker now runs in production mode (previously we had changed to run it as dev server)