### PR TITLE
Update docker run's port mapping example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We have released BYOR as a docker image for our users. The image is available in
 
 ```
 $ docker pull wwwthoughtworks/build-your-own-radar
-$ docker run --rm -p 8080:8080 -e CLIENT_ID="[Google Client ID]" wwwthoughtworks/build-your-own-radar
+$ docker run --rm -p 8080:80 -e CLIENT_ID="[Google Client ID]" wwwthoughtworks/build-your-own-radar
 $ open http://localhost:8080
 ```
 ***Notes:***


### PR DESCRIPTION
The nginx port is exposed as 80 but the current docs map through to
8080 (regression from 8ec7e75).

This commit reverts to `-p 8080:80`.