### PR TITLE
Fix test-run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Make sure you have nodejs installed.
 
 - `git clone git@github.com:thoughtworks/build-your-own-radar.git`
 - `npm install`
-- `npm quality:nonstrict` - to run your tests
+- `npm run quality` - to run your tests
 - `npm run dev` - to run application in localhost:8080. This will watch the .js and .css files and rebuild on file changes
 
 ## End to End Tests


### PR DESCRIPTION
The instructions under the `Contribute` section suggest using `npm quality:nonstrict` to run tests. I believe that that should be `npm run quality:nonstrict` instead. Furthermore, it looks as though the `quality:nonstrict` script was recently removed (in commit https://github.com/thoughtworks/build-your-own-radar/commit/460357073a6979e103af74e0c53801f08727e24b), so this should probably just be `npm run quality`.