### PR TITLE
Replace `isNew` with generic, filterable `context`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 A library that generates an interactive radar, inspired by [thoughtworks.com/radar](http://thoughtworks.com/radar).
 
+## Difference to original radar
+
+The original radar has an isNew column. This radar has a context column, that will create a second line of buttons, allowing you to filter for specific context items. While the filter is active, the other elements are greyed out.
+
 ## Demo
 
 You can see this in action at https://radar.thoughtworks.com. If you plug in [this data](https://docs.google.com/spreadsheets/d/18A7oDuavlh89rAmqcaXpqle8QLqIvlAkoEUxcObzuUM/edit#gid=1985253373) you'll see [this visualization](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fdocs.google.com%2Fspreadsheets%2Fd%2F18A7oDuavlh89rAmqcaXpqle8QLqIvlAkoEUxcObzuUM%2Fedit%23gid%3D1985253373).
@@ -24,12 +28,12 @@ You need to make your data public in a form we can digest.
 
 Create a Google Sheet. Give it at least the below column headers, and put in the content that you want:
 
-| name          | ring   | quadrant               | isNew | description                                             |
-| ------------- | ------ | ---------------------- | ----- | ------------------------------------------------------- |
-| Composer      | adopt  | tools                  | TRUE  | Although the idea of dependency management ...          |
-| Canary builds | trial  | techniques             | FALSE | Many projects have external code dependencies ...       |
-| Apache Kylin  | assess | platforms              | TRUE  | Apache Kylin is an open source analytics solution ...   |
-| JSF           | hold   | languages & frameworks | FALSE | We continue to see teams run into trouble using JSF ... |
+| name          | ring   | quadrant               | context  | description                                             |
+| ------------- | ------ | ---------------------- | -------- | ------------------------------------------------------- |
+| Composer      | adopt  | tools                  | Software | Although the idea of dependency management ...          |
+| Canary builds | trial  | techniques             | DevOps   | Many projects have external code dependencies ...       |
+| Apache Kylin  | assess | platforms              | Data     | Apache Kylin is an open source analytics solution ...   |
+| JSF           | hold   | languages & frameworks | Software | We continue to see teams run into trouble using JSF ... |
 
 ### Sharing the sheet
 
@@ -47,11 +51,11 @@ For example, a [raw URL](https://raw.githubusercontent.com/thoughtworks/build-yo
 The format is just the same as that of the Google Sheet, the example is as follows:
 
 ```
-name,ring,quadrant,isNew,description
-Composer,adopt,tools,TRUE,"Although the idea of dependency management ..."
-Canary builds,trial,techniques,FALSE,"Many projects have external code dependencies ..."
-Apache Kylin,assess,platforms,TRUE,"Apache Kylin is an open source analytics solution ..."
-JSF,hold,languages & frameworks,FALSE,"We continue to see teams run into trouble using JSF ..."
+name,ring,quadrant,context,description
+Composer,adopt,tools,Software,"Although the idea of dependency management ..."
+Canary builds,trial,techniques,DevOps,"Many projects have external code dependencies ..."
+Apache Kylin,assess,platforms,Data,"Apache Kylin is an open source analytics solution ..."
+JSF,hold,languages & frameworks,Software,"We continue to see teams run into trouble using JSF ..."
 ```
 
 If you do not want to host the CSV file publicly, you can follow [these steps](#advanced-option---docker-image-with-a-csvjson-file-from-the-host-machine) to host the file locally on your BYOR docker instance itself.
@@ -73,28 +77,28 @@ An example:
     "name": "Composer",
     "ring": "adopt",
     "quadrant": "tools",
-    "isNew": "TRUE",
+    "context": "Software",
     "description": "Although the idea of dependency management ..."
   },
   {
     "name": "Canary builds",
     "ring": "trial",
     "quadrant": "techniques",
-    "isNew": "FALSE",
+    "context": "DevOps",
     "description": "Many projects have external code dependencies ..."
   },
   {
     "name": "Apache Kylin",
     "ring": "assess",
     "quadrant": "platforms",
-    "isNew": "TRUE",
+    "context": "Data",
     "description": "Apache Kylin is an open source analytics solution ..."
   },
   {
     "name": "JSF",
     "ring": "hold",
     "quadrant": "languages & frameworks",
-    "isNew": "FALSE",
+    "context": "Software",
     "description": "We continue to see teams run into trouble using JSF ..."
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,10 +40,7 @@
         "postcss-preset-env": "^7.4.2",
         "prettier": "^2.5.1",
         "sass": "^1.53.0",
-        "sass-loader": "^12.6.0",
         "style-loader": "^3.3.1",
-        "webpack": "^5.70.0",
-        "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.7.4",
         "yargs": "^17.3.1"
       },

--- a/spec/end_to_end_tests/resources/data.json
+++ b/spec/end_to_end_tests/resources/data.json
@@ -3,28 +3,28 @@
     "name": "Babel",
     "ring": "adopt",
     "quadrant": "tools",
-    "isNew": "TRUE",
+    "context": "Software",
     "description": "test"
   },
   {
     "name": "Apache Kafka",
     "ring": "trial",
     "quadrant": "languages & frameworks",
-    "isNew": "FALSE",
+    "context": "DevOps",
     "description": "test"
   },
   {
     "name": "Android-x86",
     "ring": "assess",
     "quadrant": "platforms",
-    "isNew": "TRUE",
+    "context": "Software",
     "description": "test"
   },
   {
     "name": "GrapCloud lift and shifthQL",
     "ring": "hold",
     "quadrant": "techniques",
-    "isNew": "FALSE",
+    "context": "Data",
     "description": "test"
   }
 ]

--- a/spec/end_to_end_tests/resources/sheet.csv
+++ b/spec/end_to_end_tests/resources/sheet.csv
@@ -1,5 +1,5 @@
-name,ring,quadrant,isNew,description
-Babel,adopt,tools,TRUE,test
-Apache Kafka,trial,languages & frameworks,FALSE,test
-Android-x86,assess,platforms,TRUE,test
-Cloud lift and shift,hold,techniques,FALSE,test
+name,ring,quadrant,context,description
+Babel,adopt,tools,Software,test
+Apache Kafka,trial,languages & frameworks,DevOps,test
+Android-x86,assess,platforms,Software,test
+Cloud lift and shift,hold,techniques,Data,test

--- a/spec/models/blip-spec.js
+++ b/spec/models/blip-spec.js
@@ -28,12 +28,12 @@ describe('Blip', function () {
   it('is new', function () {
     blip = new Blip('My Blip', new Ring('My Ring'), true)
 
-    expect(blip.isNew()).toBe(true)
+    expect(blip.context()).toBe(true)
   })
 
   it('is not new', function () {
     blip = new Blip('My Blip', new Ring('My Ring'), false)
 
-    expect(blip.isNew()).toBe(false)
+    expect(blip.context()).toBe(false)
   })
 })

--- a/spec/util/contentValidator-spec.js
+++ b/spec/util/contentValidator-spec.js
@@ -5,7 +5,7 @@ const ExceptionMessages = require('../../src/util/exceptionMessages')
 describe('ContentValidator', function () {
   describe('verifyContent', function () {
     it('does not return anything if content is valid', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'context', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyContent()).not.toBeDefined()
@@ -23,7 +23,7 @@ describe('ContentValidator', function () {
 
   describe('verifyHeaders', function () {
     it('raises an error if one of the headers is empty', function () {
-      var columnNames = ['ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['ring', 'quadrant', 'context', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(function () {
@@ -32,14 +32,14 @@ describe('ContentValidator', function () {
     })
 
     it('does not return anything if the all required headers are present', function () {
-      var columnNames = ['name', 'ring', 'quadrant', 'isNew', 'description']
+      var columnNames = ['name', 'ring', 'quadrant', 'context', 'description']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()
     })
 
     it('does not care about white spaces in the headers', function () {
-      var columnNames = [' name', 'ring ', '   quadrant', 'isNew   ', '   description   ']
+      var columnNames = [' name', 'ring ', '   quadrant', 'context   ', '   description   ']
       var contentValidator = new ContentValidator(columnNames)
 
       expect(contentValidator.verifyHeaders()).not.toBeDefined()

--- a/spec/util/inputSanitizer-spec.js
+++ b/spec/util/inputSanitizer-spec.js
@@ -11,7 +11,7 @@ describe('InputSanitizer', function () {
       description: description,
       ring: '<a href="/asd">Adopt</a>',
       quadrant: '<strong>techniques and tools</strong>',
-      isNew: 'true<br>',
+      context: 'Software<br>',
     }
 
     blip = sanitizer.sanitize(rawBlip)
@@ -26,7 +26,7 @@ describe('InputSanitizer', function () {
   })
 
   it('strips out all tags from blip status', function () {
-    expect(blip.isNew).toEqual('true')
+    expect(blip.context).toEqual('Software')
   })
 
   it('strips out all tags from blip ring', function () {
@@ -53,13 +53,13 @@ describe('Input Santizer for Protected sheet', function () {
   var sanitizer, rawBlip, blip, header
   beforeAll(function () {
     sanitizer = new InputSanitizer()
-    header = ['name', 'quadrant', 'ring', 'isNew', 'description']
+    header = ['name', 'quadrant', 'ring', 'context', 'description']
 
     rawBlip = [
       "Hello <script>alert('dangerous');</script>there <h1>blip</h1>",
       '<strong>techniques & tools</strong>',
       "<a href='/asd'>Adopt</a>",
-      'true<br>',
+      'Software<br>',
       "<b>Hello</b> <script>alert('dangerous');</script>there <h1>heading</h1>",
     ]
 
@@ -75,7 +75,7 @@ describe('Input Santizer for Protected sheet', function () {
   })
 
   it('strips out all tags from blip status', function () {
-    expect(blip.isNew).toEqual('true')
+    expect(blip.context).toEqual('Software')
   })
 
   it('strips out all tags from blip ring', function () {

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -123,26 +123,6 @@ const Radar = function (size, radar) {
     })
   }
 
-  function triangle(blip, x, y, order, group) {
-    return group
-      .append('path')
-      .attr(
-        'd',
-        'M412.201,311.406c0.021,0,0.042,0,0.063,0c0.067,0,0.135,0,0.201,0c4.052,0,6.106-0.051,8.168-0.102c2.053-0.051,4.115-0.102,8.176-0.102h0.103c6.976-0.183,10.227-5.306,6.306-11.53c-3.988-6.121-4.97-5.407-8.598-11.224c-1.631-3.008-3.872-4.577-6.179-4.577c-2.276,0-4.613,1.528-6.48,4.699c-3.578,6.077-3.26,6.014-7.306,11.723C402.598,306.067,405.426,311.406,412.201,311.406',
-      )
-      .attr(
-        'transform',
-        'scale(' +
-          blip.width / 34 +
-          ') translate(' +
-          (-404 + x * (34 / blip.width) - 17) +
-          ', ' +
-          (-282 + y * (34 / blip.width) - 17) +
-          ')',
-      )
-      .attr('class', order)
-  }
-
   function triangleLegend(x, y, group) {
     return group
       .append('path')
@@ -166,12 +146,12 @@ const Radar = function (size, radar) {
       .attr(
         'transform',
         'scale(' +
-          blip.width / 34 +
-          ') translate(' +
-          (-404 + x * (34 / blip.width) - 17) +
-          ', ' +
-          (-282 + y * (34 / blip.width) - 17) +
-          ')',
+        blip.width / 34 +
+        ') translate(' +
+        (-404 + x * (34 / blip.width) - 17) +
+        ', ' +
+        (-282 + y * (34 / blip.width) - 17) +
+        ')',
       )
       .attr('class', order)
   }
@@ -308,11 +288,8 @@ const Radar = function (size, radar) {
       .attr('class', 'blip-link')
       .attr('id', 'blip-link-' + blip.number())
 
-    if (blip.isNew()) {
-      triangle(blip, x, y, order, group)
-    } else {
-      circle(blip, x, y, order, group)
-    }
+    console.log("Blib context:", blip.context())
+    circle(blip, x, y, blip.context(), group)
 
     group
       .append('text')
@@ -585,9 +562,9 @@ const Radar = function (size, radar) {
       .append('p')
       .html(
         'Powered by <a href="https://www.thoughtworks.com"> Thoughtworks</a>. ' +
-          'By using this service you agree to <a href="https://www.thoughtworks.com/radar/tos">Thoughtworks\' terms of use</a>. ' +
-          'You also agree to our <a href="https://www.thoughtworks.com/privacy-policy">privacy policy</a>, which describes how we will gather, use and protect any personal data contained in your public Google Sheet. ' +
-          'This software is <a href="https://github.com/thoughtworks/build-your-own-radar">open source</a> and available for download and self-hosting.',
+        'By using this service you agree to <a href="https://www.thoughtworks.com/radar/tos">Thoughtworks\' terms of use</a>. ' +
+        'You also agree to our <a href="https://www.thoughtworks.com/privacy-policy">privacy policy</a>, which describes how we will gather, use and protect any personal data contained in your public Google Sheet. ' +
+        'This software is <a href="https://github.com/thoughtworks/build-your-own-radar">open source</a> and available for download and self-hosting.',
       )
   }
 

--- a/src/graphing/radar.js
+++ b/src/graphing/radar.js
@@ -12,7 +12,7 @@ const MIN_BLIP_WIDTH = 12
 const ANIMATION_DURATION = 1000
 
 const Radar = function (size, radar) {
-  var svg, radarElement, quadrantButtons, buttonsGroup, header, alternativeDiv
+  var svg, radarElement, quadrantButtons, buttonsGroup, header, alternativeDiv, selectedContext
 
   var tip = d3tip()
     .attr('class', 'd3-tip')
@@ -123,19 +123,6 @@ const Radar = function (size, radar) {
     })
   }
 
-  function triangleLegend(x, y, group) {
-    return group
-      .append('path')
-      .attr(
-        'd',
-        'M412.201,311.406c0.021,0,0.042,0,0.063,0c0.067,0,0.135,0,0.201,0c4.052,0,6.106-0.051,8.168-0.102c2.053-0.051,4.115-0.102,8.176-0.102h0.103c6.976-0.183,10.227-5.306,6.306-11.53c-3.988-6.121-4.97-5.407-8.598-11.224c-1.631-3.008-3.872-4.577-6.179-4.577c-2.276,0-4.613,1.528-6.48,4.699c-3.578,6.077-3.26,6.014-7.306,11.723C402.598,306.067,405.426,311.406,412.201,311.406',
-      )
-      .attr(
-        'transform',
-        'scale(' + 22 / 64 + ') translate(' + (-404 + x * (64 / 22) - 17) + ', ' + (-282 + y * (64 / 22) - 17) + ')',
-      )
-  }
-
   function circle(blip, x, y, order, group) {
     return (group || svg)
       .append('path')
@@ -154,19 +141,6 @@ const Radar = function (size, radar) {
         ')',
       )
       .attr('class', order)
-  }
-
-  function circleLegend(x, y, group) {
-    return (group || svg)
-      .append('path')
-      .attr(
-        'd',
-        'M420.084,282.092c-1.073,0-2.16,0.103-3.243,0.313c-6.912,1.345-13.188,8.587-11.423,16.874c1.732,8.141,8.632,13.711,17.806,13.711c0.025,0,0.052,0,0.074-0.003c0.551-0.025,1.395-0.011,2.225-0.109c4.404-0.534,8.148-2.218,10.069-6.487c1.747-3.886,2.114-7.993,0.913-12.118C434.379,286.944,427.494,282.092,420.084,282.092',
-      )
-      .attr(
-        'transform',
-        'scale(' + 22 / 64 + ') translate(' + (-404 + x * (64 / 22) - 17) + ', ' + (-282 + y * (64 / 22) - 17) + ')',
-      )
   }
 
   function addRing(ring, order) {
@@ -250,7 +224,7 @@ const Radar = function (size, radar) {
         const coordinates = findBlipCoordinates(blip, minRadius, maxRadius, startAngle, allBlipCoordinatesInRing)
 
         allBlipCoordinatesInRing.push(coordinates)
-        drawBlipInCoordinates(blip, coordinates, order, quadrantGroup, ringList)
+        drawBlipInCoordinates(blip, coordinates, radar.contexts(), quadrantGroup, ringList)
       })
     })
   }
@@ -279,17 +253,18 @@ const Radar = function (size, radar) {
     }
   }
 
-  function drawBlipInCoordinates(blip, coordinates, order, quadrantGroup, ringList) {
+  function drawBlipInCoordinates(blip, coordinates, contexts, quadrantGroup, ringList) {
     var x = coordinates[0]
     var y = coordinates[1]
 
+    const context_class = `context_${[...contexts].indexOf(blip.context())}`
+
     var group = quadrantGroup
       .append('g')
-      .attr('class', 'blip-link')
+      .attr('class', 'blip-link ' + context_class)
       .attr('id', 'blip-link-' + blip.number())
 
-    console.log("Blib context:", blip.context())
-    circle(blip, x, y, blip.context(), group)
+    circle(blip, x, y, context_class, group)
 
     group
       .append('text')
@@ -305,7 +280,7 @@ const Radar = function (size, radar) {
     var blipText = blip.number() + '. ' + blip.name() + (blip.topic() ? '. - ' + blip.topic() : '')
     blipListItem
       .append('div')
-      .attr('class', 'blip-list-item')
+      .attr('class', 'blip-list-item ' + context_class)
       .attr('id', 'blip-list-item-' + blip.number())
       .text(blipText)
 
@@ -370,64 +345,6 @@ const Radar = function (size, radar) {
 
   function removeRadarLegend() {
     d3.select('.legend').remove()
-  }
-
-  function drawLegend(order) {
-    removeRadarLegend()
-
-    var triangleKey = 'New or moved'
-    var circleKey = 'No change'
-
-    var container = d3
-      .select('svg')
-      .append('g')
-      .attr('class', 'legend legend' + '-' + order)
-
-    var x = 10
-    var y = 10
-
-    if (order === 'first') {
-      x = (4 * size) / 5
-      y = (1 * size) / 5
-    }
-
-    if (order === 'second') {
-      x = (1 * size) / 5 - 15
-      y = (1 * size) / 5 - 20
-    }
-
-    if (order === 'third') {
-      x = (1 * size) / 5 - 15
-      y = (4 * size) / 5 + 15
-    }
-
-    if (order === 'fourth') {
-      x = (4 * size) / 5
-      y = (4 * size) / 5
-    }
-
-    d3.select('.legend')
-      .attr('class', 'legend legend-' + order)
-      .transition()
-      .style('visibility', 'visible')
-
-    triangleLegend(x, y, container)
-
-    container
-      .append('text')
-      .attr('x', x + 15)
-      .attr('y', y + 5)
-      .attr('font-size', '0.8em')
-      .text(triangleKey)
-
-    circleLegend(x, y + 20, container)
-
-    container
-      .append('text')
-      .attr('x', x + 15)
-      .attr('y', y + 25)
-      .attr('font-size', '0.8em')
-      .text(circleKey)
   }
 
   function redrawFullRadar() {
@@ -553,6 +470,29 @@ const Radar = function (size, radar) {
     AutoComplete('#auto-complete', quadrants, searchBlip)
   }
 
+  function plotContextButtons(contexts) {
+    const contextBtnGroup = alternativeDiv
+      .append('div')
+      .attr('class', 'context-btn--group');
+    function addButton(context, index) {
+      radarElement.append('div').attr('class', 'contexts-table context_' + index)
+
+      contextBtnGroup
+        .append('div')
+        .attr('class', 'button context_' + index + ' full-view')
+        .text(context)
+        .on('click', selectContext.bind({}, index))
+    }
+
+    contextBtnGroup
+      .append('div')
+      .attr('class', 'button full-view')
+      .text("All")
+      .on('click', unselectContext.bind({}));
+
+    [...contexts].forEach((context, index) => addButton(context, index))
+  }
+
   function plotRadarFooter() {
     d3.select('body')
       .insert('div', '#radar-plot + *')
@@ -577,12 +517,25 @@ const Radar = function (size, radar) {
     d3.selectAll('.quadrant-group:not(.quadrant-group-' + order + ')').style('opacity', 1)
   }
 
+  function unselectContext(order) {
+    d3.selectAll(`.quadrant-group .blip-link`).style('opacity', 1)
+    d3.selectAll(`.quadrant-table .blip-list-item`).style('opacity', 1)
+  }
+
+  function selectContext(order) {
+    selectedContext = `.context_${order}`
+    d3.selectAll(`.quadrant-group .blip-link:not(${selectedContext})`).style('opacity', 0.1)
+    d3.selectAll(`.quadrant-group .blip-link${selectedContext}`).style('opacity', 1)
+    d3.selectAll(`.quadrant-table .blip-list-item:not(${selectedContext})`).style('opacity', 0.1)
+    d3.selectAll(`.quadrant-table .blip-list-item${selectedContext}`).style('opacity', 1)
+  }
+
   function selectQuadrant(order, startAngle) {
     d3.selectAll('.home-link').classed('selected', false)
     createHomeLink(d3.select('header'))
 
-    d3.selectAll('.button').classed('selected', false).classed('full-view', false)
-    d3.selectAll('.button.' + order).classed('selected', true)
+    d3.selectAll('.quadrant-btn--group .button').classed('selected', false).classed('full-view', false)
+    d3.selectAll('.quadrant-btn--group .button.' + order).classed('selected', true)
     d3.selectAll('.quadrant-table').classed('selected', false)
     d3.selectAll('.quadrant-table.' + order).classed('selected', true)
     d3.selectAll('.blip-item-description').classed('expanded', false)
@@ -625,10 +578,6 @@ const Radar = function (size, radar) {
       .duration(ANIMATION_DURATION)
       .style('pointer-events', 'none')
       .attr('transform', 'translate(' + translateXAll + ',' + translateYAll + ')scale(0)')
-
-    if (d3.select('.legend.legend-' + order).empty()) {
-      drawLegend(order)
-    }
   }
 
   self.init = function () {
@@ -670,6 +619,7 @@ const Radar = function (size, radar) {
 
     rings = radar.rings()
     quadrants = radar.quadrants()
+    contexts = radar.contexts()
     alternatives = radar.getAlternatives()
     currentSheet = radar.getCurrentSheet()
 
@@ -688,6 +638,7 @@ const Radar = function (size, radar) {
       plotAlternativeRadars(alternatives, currentSheet)
     }
 
+    plotContextButtons(contexts)
     plotQuadrantButtons(quadrants)
 
     radarElement.style('height', size + 14 + 'px')

--- a/src/models/blip.js
+++ b/src/models/blip.js
@@ -1,5 +1,5 @@
 const IDEAL_BLIP_WIDTH = 22
-const Blip = function (name, ring, isNew, topic, description) {
+const Blip = function (name, ring, context, topic, description) {
   var self, number
 
   self = {}
@@ -19,8 +19,8 @@ const Blip = function (name, ring, isNew, topic, description) {
     return description || ''
   }
 
-  self.isNew = function () {
-    return isNew
+  self.context = function () {
+    return context
   }
 
   self.ring = function () {

--- a/src/models/radar.js
+++ b/src/models/radar.js
@@ -8,7 +8,7 @@ const _ = {
 }
 
 const Radar = function () {
-  var self, quadrants, blipNumber, addingQuadrant, alternatives, currentSheetName
+  var self, quadrants, contexts, blipNumber, addingQuadrant, alternatives, currentSheetName
 
   blipNumber = 0
   addingQuadrant = 0
@@ -67,6 +67,13 @@ const Radar = function () {
     }, [])
   }
 
+  function allContexts() {
+    return allBlips().reduce((contexts, blib) => {
+      contexts.add(blib.context())
+      return contexts
+    }, new Set())
+  }
+
   self.rings = function () {
     return _.sortBy(
       _.map(
@@ -85,6 +92,9 @@ const Radar = function () {
 
   self.quadrants = function () {
     return quadrants
+  }
+  self.contexts = function () {
+    return allContexts()
   }
 
   return self

--- a/src/stylesheets/_header.scss
+++ b/src/stylesheets/_header.scss
@@ -60,6 +60,12 @@ header {
   }
 }
 
+.context-btn--group {
+  .button {
+    border-radius: 50%;
+  }
+}
+
 .quadrant-btn--group,
 .multiple-sheet-button-group {
   text-align: left;
@@ -108,44 +114,44 @@ header {
     transform: translate(0, -2px);
     opacity: 0.85;
 
-    &.first {
+    &.first, &.context_0 {
       color: white;
       background-color: $green;
     }
 
-    &.second {
+    &.second, &.context_1 {
       color: white;
       background-color: $blue;
     }
 
-    &.third {
+    &.third, &.context_2 {
       color: white;
       background-color: $orange;
     }
 
-    &.fourth {
+    &.fourth, &.context_3 {
       color: white;
       background-color: $violet;
     }
   }
 
   &.full-view {
-    &.first {
+    &.first, &.context_0 {
       background-color: $green;
       color: $white;
     }
 
-    &.second {
+    &.second, &.context_1 {
       background-color: $blue;
       color: $white;
     }
 
-    &.third {
+    &.third, &.context_2 {
       background-color: $orange;
       color: $white;
     }
 
-    &.fourth {
+    &.fourth, &.context_3 {
       background-color: $violet;
       color: $white;
     }

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -236,6 +236,15 @@ body {
       .blip-link {
         text-decoration: none;
         cursor: pointer;
+        & .Software {
+          fill: $green;
+        }
+        & .DevOps {
+          fill: $blue;
+        }
+        & .Data {
+          fill: $orange;
+        }
       }
 
       .quadrant-group {

--- a/src/stylesheets/base.scss
+++ b/src/stylesheets/base.scss
@@ -236,14 +236,21 @@ body {
       .blip-link {
         text-decoration: none;
         cursor: pointer;
-        & .Software {
+
+        .context_0  {
           fill: $green;
         }
-        & .DevOps {
+
+        .context_1 {
           fill: $blue;
         }
-        & .Data {
+
+        .context_2 {
           fill: $orange;
+        }
+
+        .context_3 {
+          fill: $violet;
         }
       }
 

--- a/src/util/contentValidator.js
+++ b/src/util/contentValidator.js
@@ -21,7 +21,7 @@ const ContentValidator = function (columnNames) {
   }
 
   self.verifyHeaders = function () {
-    _.each(['name', 'ring', 'quadrant', 'isNew', 'description'], function (field) {
+    _.each(['name', 'ring', 'quadrant', 'context', 'description'], function (field) {
       if (columnNames.indexOf(field) === -1) {
         throw new MalformedDataError(ExceptionMessages.MISSING_HEADERS)
       }

--- a/src/util/exceptionMessages.js
+++ b/src/util/exceptionMessages.js
@@ -3,7 +3,7 @@ const ExceptionMessages = {
   TOO_MANY_RINGS: 'More than 4 rings.',
   MISSING_HEADERS:
     'Document is missing one or more required headers or they are misspelled. ' +
-    'Check that your document contains headers for "name", "ring", "quadrant", "isNew", "description".',
+    'Check that your document contains headers for "name", "ring", "quadrant", "context", "description".',
   MISSING_CONTENT: 'Document is missing content.',
   LESS_THAN_FOUR_QUADRANTS:
     'There are less than 4 quadrant names listed in your data. Check the quadrant column for errors.',

--- a/src/util/factory.js
+++ b/src/util/factory.js
@@ -39,7 +39,7 @@ const plotRadar = function (title, blips, currentRadarName, alternativeRadars) {
 
   _.each(rings, function (ringName, i) {
     if (i === maxRings) {
-      throw new MalformedDataError(ExceptionMessages.TOO_MANY_RINGS)
+      throw new MalformedDataError(ExceptionMessages.TOO_MANY_RINGS + JSON.stringify(rings))
     }
     ringMap[ringName] = new Ring(ringName, i)
   })
@@ -50,7 +50,7 @@ const plotRadar = function (title, blips, currentRadarName, alternativeRadars) {
       quadrants[blip.quadrant] = new Quadrant(_.capitalize(blip.quadrant))
     }
     quadrants[blip.quadrant].add(
-      new Blip(blip.name, ringMap[blip.ring], blip.isNew.toLowerCase() === 'true', blip.topic, blip.description),
+      new Blip(blip.name, ringMap[blip.ring], blip.context, blip.topic, blip.description),
     )
   })
 
@@ -313,9 +313,9 @@ function plotFooter(content) {
     .append('p')
     .html(
       'Powered by <a href="https://www.thoughtworks.com"> Thoughtworks</a>. ' +
-        'By using this service you agree to <a href="https://www.thoughtworks.com/radar/tos">Thoughtworks\' terms of use</a>. ' +
-        'You also agree to our <a href="https://www.thoughtworks.com/privacy-policy">privacy policy</a>, which describes how we will gather, use and protect any personal data contained in your public Google Sheet. ' +
-        'This software is <a href="https://github.com/thoughtworks/build-your-own-radar">open source</a> and available for download and self-hosting.',
+      'By using this service you agree to <a href="https://www.thoughtworks.com/radar/tos">Thoughtworks\' terms of use</a>. ' +
+      'You also agree to our <a href="https://www.thoughtworks.com/privacy-policy">privacy policy</a>, which describes how we will gather, use and protect any personal data contained in your public Google Sheet. ' +
+      'This software is <a href="https://github.com/thoughtworks/build-your-own-radar">open source</a> and available for download and self-hosting.',
     )
 }
 

--- a/src/util/inputSanitizer.js
+++ b/src/util/inputSanitizer.js
@@ -32,7 +32,7 @@ const InputSanitizer = function () {
     var blip = trimWhiteSpaces(rawBlip)
     blip.description = sanitizeHtml(blip.description, relaxedOptions)
     blip.name = sanitizeHtml(blip.name, restrictedOptions)
-    blip.isNew = sanitizeHtml(blip.isNew, restrictedOptions)
+    blip.context = sanitizeHtml(blip.context, restrictedOptions)
     blip.ring = sanitizeHtml(blip.ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(blip.quadrant, restrictedOptions)
 
@@ -44,19 +44,19 @@ const InputSanitizer = function () {
 
     const descriptionIndex = header.indexOf('description')
     const nameIndex = header.indexOf('name')
-    const isNewIndex = header.indexOf('isNew')
+    const contextIndex = header.indexOf('context')
     const quadrantIndex = header.indexOf('quadrant')
     const ringIndex = header.indexOf('ring')
 
     const description = descriptionIndex === -1 ? '' : blip[descriptionIndex]
     const name = nameIndex === -1 ? '' : blip[nameIndex]
-    const isNew = isNewIndex === -1 ? '' : blip[isNewIndex]
+    const context = contextIndex === -1 ? '' : blip[contextIndex]
     const ring = ringIndex === -1 ? '' : blip[ringIndex]
     const quadrant = quadrantIndex === -1 ? '' : blip[quadrantIndex]
 
     blip.description = sanitizeHtml(description, relaxedOptions)
     blip.name = sanitizeHtml(name, restrictedOptions)
-    blip.isNew = sanitizeHtml(isNew, restrictedOptions)
+    blip.context = sanitizeHtml(context, restrictedOptions)
     blip.ring = sanitizeHtml(ring, restrictedOptions)
     blip.quadrant = sanitizeHtml(quadrant, restrictedOptions)
 


### PR DESCRIPTION
_tl;dr_

After this change, instead of having a fixed `isNew`, the technology radar would contain a filterable context field. This would be a breaking change

## Rationale

For our usage of the technology radar, `isNew` doesn't provide that much value, as the new items we can get from the git history for the csv file. As we have a lot of blips, though, we needed a way of clustering and filtering them

## Solution

By replacing `isNew` with `context`, we can use more values, or oeven keep the isNew functionality. I did decide on no longer supporting `isNew`, as I felt this would add complexity for downwards compatibility which wouldn't make a lot of sense in the long run. If you feel that compatibility is important let me know, and I'll add a commit that triggers the old functionality in case isNew is in the header, still.

The context values are read, and will create colored blips for up to 4 different contexts. Additionally, it will create a filter element in the header, which will highlight the respective blips.

See an example here: 

![Filterable technology radar](https://user-images.githubusercontent.com/2781095/193998139-3c7175d8-d2e4-4934-a515-237345500742.png)

## Benefits

- Opens up new opportunities for displaying contextual information on the radar
- Even for the then-replaced usecase of `isNew`, will allow filtering on the radar, thus improving usability

## Trade-Offs

- Breaking change
- The additional menu item fills up space
- As the color-palette is limited, same colors are used for different meanings
- `context` is not really a good name

Super interested to hear your thoughts on this change

