### PR TITLE
fix: vscode ide setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,1 +1,8 @@
-{ "recommendations": ["esbenp.prettier-vscode", "EditorConfig.EditorConfig"] }
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "orta.vscode-jest",
+        "editorconfig.editorconfig"
+    ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,1 @@
-{
-    "recommendations": [
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "orta.vscode-jest",
-        "editorconfig.editorconfig"
-    ]
-}
+{ "recommendations": ["esbenp.prettier-vscode", "EditorConfig.EditorConfig"] }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
+  "prettier.enable": true,
   "prettier.prettierPath": "./node_modules/prettier",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,13 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "prettier.prettierPath": "./node_modules/prettier",
   "editor.formatOnSave": true,
-  "editor.tabSize": 2
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }


### PR DESCRIPTION
The existing vscode settings would caus linting issues on-save.  This PR addresses this so that the on-save prettier formatting now matches the `npm run lint-prettier:check` and `npm run lint-prettier:fix` behavior