### PR TITLE
chore: update cypress version to mitigate critical vulnerability - CV…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "babel-loader": "^9.1.3",
         "css-loader": "^6.8.1",
         "cssnano": "^6.0.1",
-        "cypress": "^13.1.0",
+        "cypress": "^13.2.0",
         "dotenv": "^16.3.1",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
@@ -3903,9 +3903,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "node_modules/@types/qs": {
@@ -6065,15 +6065,15 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
-      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
     "cssnano": "^6.0.1",
-    "cypress": "^13.1.0",
+    "cypress": "^13.2.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
CVE-2020-36632 - is blocking me from pulling the docker image into my place of work.  I require a new docker image with this update when possible.