### PR TITLE
chore: update cypress version to mitigate critical vulnerability - CV…

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Google OAuth Client ID and API Key can be obtained from your Google Developer Co
 ```
 export CLIENT_ID=[Google Client ID]
 ```
+
 **_Note:_** Make sure to set the "Authorized JavaScript origins" field for the Client ID to the right origin domain, with port, where the app is hosted. Examples: `http://localhost:8080` or `https://radar.thoughtworks.com`.
 
 Optionally, API Key can be set to bypass Google Authentication for public sheets.
@@ -218,6 +219,7 @@ Make sure you have nodejs installed. You can run `nvm use` to use the version us
 To run End to End tests, start the dev server and follow the required steps below:
 
 - To run in headless mode:
+
   - add a new environment variable `TEST_URL` and set it to 'http://localhost:8080'
   - `npm run test:e2e-headless`
 
@@ -228,6 +230,7 @@ To run End to End tests, start the dev server and follow the required steps belo
   - Click on the spec to run it's tests
 
 **_Notes:_**
+
 - Currently, end to end tests are not supported for private Google Sheets, as it requires interacting with the Google One Tap popup.
 - To run end to end tests for public Google Sheets, the `CLIENT_ID` and `API_KEY` environment variables need to set as well (steps details [here](#more-complex-usage)), to provide Cypress with an authenticated session (without having to interact with Google's auth popups).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "babel-loader": "^9.1.3",
         "css-loader": "^6.8.1",
         "cssnano": "^6.0.1",
-        "cypress": "^13.1.0",
+        "cypress": "^13.2.0",
         "dotenv": "^16.3.1",
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
@@ -3903,9 +3903,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.18.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.48.tgz",
-      "integrity": "sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==",
+      "version": "18.18.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.0.tgz",
+      "integrity": "sha512-3xA4X31gHT1F1l38ATDIL9GpRLdwVhnEFC8Uikv5ZLlXATwrCYyPq7ZWHxzxc3J/30SUiwiYT+bQe0/XvKlWbw==",
       "dev": true
     },
     "node_modules/@types/qs": {
@@ -6065,15 +6065,15 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.1.0.tgz",
-      "integrity": "sha512-LUKxCYlB973QBFls1Up4FAE9QIYobT+2I8NvvAwMfQS2YwsWbr6yx7y9hmsk97iqbHkKwZW3MRjoK1RToBFVdQ==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.2.0.tgz",
+      "integrity": "sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",
         "@cypress/xvfb": "^1.2.4",
-        "@types/node": "^16.18.39",
+        "@types/node": "^18.17.5",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "arch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "babel-loader": "^9.1.3",
     "css-loader": "^6.8.1",
     "cssnano": "^6.0.1",
-    "cypress": "^13.1.0",
+    "cypress": "^13.2.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",


### PR DESCRIPTION
CVE-2020-36632 is blocking me from pulling the docker image into my place of work. I require a new docker image with this update when possible.