### PR TITLE
Upgrade Node.js to 20 (current LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,15 @@
 FROM nginx:1.23.0
 
-RUN apt-get update && apt-get upgrade -y
+ARG NODE_MAJOR=20
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
-
-RUN                                                                       \
-  apt-get install -y                                                      \
-  libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3    \
-  libxss1 libasound2 libxtst6 xauth xvfb g++ make
+RUN apt-get update && \
+  apt-get upgrade --yes && \
+  apt-get install --yes ca-certificates curl gnupg libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb g++ make && \
+  mkdir -p /etc/apt/keyrings/ && \
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+  echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+  apt-get update && \
+  apt-get install --yes nodejs
 
 WORKDIR /src/build-your-own-radar
 COPY package.json ./


### PR DESCRIPTION
The script for 18 gives a 1 minute timeout now and urges to upgrade. This commit fixes it.