### PR TITLE
fix: codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-- @thoughtworks/tw-digital
-- @will-amaral
+* @thoughtworks/tw-digital @will-amaral


### PR DESCRIPTION
From past ~_nightmares_~ experience, codeowners need to be on the same line otherwise the last match survives 😅 

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
> _If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner._