### PR TITLE
Defect/zooming fix

### DIFF
--- a/src/graphing/components/quadrants.js
+++ b/src/graphing/components/quadrants.js
@@ -87,10 +87,6 @@ function selectRadarQuadrant(order, startAngle, name) {
     .style('right', translateLeftRightValues[order].right)
     .style('box-sizing', 'border-box')
 
-  if (window.innerWidth < uiConfig.tabletViewWidth) {
-    svg.style('margin', 'unset')
-  }
-
   svg
     .attr('transform', `scale(${scale})`)
     .style('transform', `scale(${scale})`)

--- a/src/stylesheets/_quadrants.scss
+++ b/src/stylesheets/_quadrants.scss
@@ -53,7 +53,6 @@
   svg#radar-plot {
     margin: 0 auto;
     transition: all 1s ease;
-    position: absolute;
     left: 0;
     right: 0;
 


### PR DESCRIPTION
# Steps to reproduce the defect 

## Open Thoughtworks Radar 
<img width="1746" alt="Screenshot 2024-08-27 at 2 54 02 PM" src="https://github.com/user-attachments/assets/d4f3529b-2e35-4045-96cc-45085158319d">

## Zoom into the 4 image quadrant view (i.e. 150% zoom)
<img width="1669" alt="Screenshot 2024-08-27 at 2 54 19 PM" src="https://github.com/user-attachments/assets/fbb55978-d7ed-4799-8762-dcd4581f15a2">

## Click on any one of the 4 quadrants (i.e. switch tabs on the radar view)
<img width="1613" alt="Screenshot 2024-08-27 at 2 54 39 PM" src="https://github.com/user-attachments/assets/60cbd19a-293f-4a32-94e9-dab38646becc">

## Navigate Back to "All quadrants" view
<img width="1693" alt="Screenshot 2024-08-27 at 2 54 56 PM" src="https://github.com/user-attachments/assets/9b42351f-89f8-4637-943b-77d0099dbf8e">

## Zoom out again in order to produce this defect.
<img width="1694" alt="Screenshot 2024-08-27 at 2 55 11 PM" src="https://github.com/user-attachments/assets/c4a2ce45-7f98-4653-b34b-037addeb48a3">

## When We zoom out we see that the radar has shifted off-centre
<img width="1629" alt="Screenshot 2024-08-27 at 2 55 37 PM" src="https://github.com/user-attachments/assets/d3381655-b47f-4ecd-b824-84292dbdecb8">
(Fix for this issue in Commit: 1) : [Zooming in and out after switching radar tabs, UI break fixed]

## We can also notice that the footer has moved up behind the radar and is hidden by the radar.
<img width="1662" alt="Screenshot 2024-08-27 at 3 04 24 PM" src="https://github.com/user-attachments/assets/ad1813da-8789-448b-a640-1a7a152f04c8">
(Fix for this issue in Commit: 2) : [Footer appearing behind the radar after zooming out, fixed]

## Post fixes, View
<img width="1746" alt="Screenshot 2024-08-27 at 2 54 02 PM" src="https://github.com/user-attachments/assets/d4f3529b-2e35-4045-96cc-45085158319d">
