### PR TITLE
Fixing a transform origin issue on initial quadrant animation

### DIFF
--- a/src/stylesheets/_quadrants.scss
+++ b/src/stylesheets/_quadrants.scss
@@ -56,6 +56,7 @@
     position: absolute;
     left: 0;
     right: 0;
+    transform-origin: top center;
 
     @if $UIRefresh2022 {
       display: none;


### PR DESCRIPTION
I noticed an issue on initial quadrant animation that is inconsistent with subsequent animations. The animation appeared to lift the quadrant up and over the sub-nav bar. After the first time it was aligned with this sub-nav bar. This single line change makes the initial animation consistent with further sub-nav animations on clicking the links.