### PR TITLE
feat(sanitizer): allow <code> and <pre>

### DIFF
--- a/src/util/inputSanitizer.js
+++ b/src/util/inputSanitizer.js
@@ -5,9 +5,10 @@ const _ = {
 
 const InputSanitizer = function () {
   var relaxedOptions = {
-    allowedTags: ['b', 'i', 'em', 'strong', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ul', 'br', 'p', 'u'],
+    allowedTags: ['b', 'i', 'em', 'strong', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ul', 'br', 'p', 'u', 'code', 'pre'],
     allowedAttributes: {
       a: ['href', 'target', 'rel'],
+      code: ['classes'],
     },
   }
 

--- a/src/util/inputSanitizer.js
+++ b/src/util/inputSanitizer.js
@@ -5,7 +5,26 @@ const _ = {
 
 const InputSanitizer = function () {
   var relaxedOptions = {
-    allowedTags: ['b', 'i', 'em', 'strong', 'a', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'li', 'ul', 'br', 'p', 'u', 'code', 'pre'],
+    allowedTags: [
+      'b',
+      'i',
+      'em',
+      'strong',
+      'a',
+      'h1',
+      'h2',
+      'h3',
+      'h4',
+      'h5',
+      'h6',
+      'li',
+      'ul',
+      'br',
+      'p',
+      'u',
+      'code',
+      'pre',
+    ],
     allowedAttributes: {
       a: ['href', 'target', 'rel'],
       code: ['classes'],


### PR DESCRIPTION
Allow `<code>` and `<pre>` tags so users can render markdown code blocks.

Before (tags not allowed, renders text raw):

<img width="832" height="735" alt="image" src="https://github.com/user-attachments/assets/d1cdf73b-abb1-4573-bdf7-c87a947fbc48" />


After (rendered `json` code block with custom styling):

https://github.com/user-attachments/assets/ac9cdbc7-81e9-41dd-baaa-3d7cb14d683e

