### PR TITLE
Fix: Enhance autocomplete search for special characters (accents)

### DIFF
--- a/spec/util/autoComplete-spec.js
+++ b/spec/util/autoComplete-spec.js
@@ -1,0 +1,56 @@
+const { normalizeText } = require('../../src/util/textNormalizer')
+
+describe('autoComplete', () => {
+  describe('normalizeText', () => {
+    it('should convert text to lowercase', () => {
+      expect(normalizeText('HELLO WORLD')).toBe('hello world')
+      expect(normalizeText('Test Case')).toBe('test case')
+    })
+
+    it('should remove Portuguese accents', () => {
+      expect(normalizeText('Autorização')).toBe('autorizacao')
+      expect(normalizeText('Experiência')).toBe('experiencia')
+      expect(normalizeText('ação')).toBe('acao')
+      expect(normalizeText('coração')).toBe('coracao')
+    })
+
+    it('should remove Spanish accents', () => {
+      expect(normalizeText('señor')).toBe('senor')
+      expect(normalizeText('niño')).toBe('nino')
+      expect(normalizeText('mañana')).toBe('manana')
+    })
+
+    it('should remove French accents', () => {
+      expect(normalizeText('café')).toBe('cafe')
+      expect(normalizeText('résumé')).toBe('resume')
+      expect(normalizeText('naïve')).toBe('naive')
+      expect(normalizeText('façade')).toBe('facade')
+    })
+
+    it('should remove German umlauts', () => {
+      expect(normalizeText('über')).toBe('uber')
+      expect(normalizeText('Mädchen')).toBe('madchen')
+      expect(normalizeText('schön')).toBe('schon')
+    })
+
+    it('should handle mixed accented and non-accented text', () => {
+      expect(normalizeText('Continuous Delivery práticas')).toBe('continuous delivery praticas')
+      expect(normalizeText('Test Automation técnicas')).toBe('test automation tecnicas')
+    })
+
+    it('should preserve text without accents', () => {
+      expect(normalizeText('hello world')).toBe('hello world')
+      expect(normalizeText('Kubernetes')).toBe('kubernetes')
+      expect(normalizeText('React.js')).toBe('react.js')
+    })
+
+    it('should handle empty string', () => {
+      expect(normalizeText('')).toBe('')
+    })
+
+    it('should handle numbers and special characters', () => {
+      expect(normalizeText('Test123!')).toBe('test123!')
+      expect(normalizeText('hello@world.com')).toBe('hello@world.com')
+    })
+  })
+})

--- a/src/util/autoComplete.js
+++ b/src/util/autoComplete.js
@@ -2,6 +2,7 @@ const $ = require('jquery')
 require('jquery-ui/ui/widgets/autocomplete')
 
 const config = require('../config')
+const { normalizeText } = require('./textNormalizer')
 const featureToggles = config().featureToggles
 
 $.widget('custom.radarcomplete', $.ui.autocomplete, {
@@ -36,8 +37,8 @@ const AutoComplete = (el, quadrants, cb) => {
       appendTo: '.search-container',
       source: (request, response) => {
         const matches = blips.filter(({ blip }) => {
-          const searchable = `${blip.name()} ${blip.description()}`.toLowerCase()
-          return request.term.split(' ').every((term) => searchable.includes(term.toLowerCase()))
+          const searchable = normalizeText(`${blip.name()} ${blip.description()}`)
+          return request.term.split(' ').every((term) => searchable.includes(normalizeText(term)))
         })
         response(matches.map((item) => ({ ...item, value: item.blip.name() })))
       },
@@ -47,8 +48,8 @@ const AutoComplete = (el, quadrants, cb) => {
     $(el).radarcomplete({
       source: (request, response) => {
         const matches = blips.filter(({ blip }) => {
-          const searchable = `${blip.name()} ${blip.description()}`.toLowerCase()
-          return request.term.split(' ').every((term) => searchable.includes(term.toLowerCase()))
+          const searchable = normalizeText(`${blip.name()} ${blip.description()}`)
+          return request.term.split(' ').every((term) => searchable.includes(normalizeText(term)))
         })
         response(matches.map((item) => ({ ...item, value: item.blip.name() })))
       },

--- a/src/util/textNormalizer.js
+++ b/src/util/textNormalizer.js
@@ -1,0 +1,16 @@
+/**
+ * Normalize text by removing diacritical marks for accent-insensitive search
+ * This allows searching for "Autorizacao" to match "Autorização" (Portuguese)
+ * or "Experiencia" to match "Experiência"
+ *
+ * @param {string} text - The text to normalize
+ * @returns {string} - Lowercase text with diacritical marks removed
+ */
+const normalizeText = (text) => {
+  return text
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+}
+
+module.exports = { normalizeText }


### PR DESCRIPTION
## Summary
Enhances the autocomplete search to support special characters and accents, making the search accessible for non-English users (Portuguese, Spanish, French, German, etc.).

## Problem
The autocomplete search did not match words containing accented characters. For example, searching for 'Autorizacao' would not find 'Autorização', and 'Experiencia' would not match 'Experiência'.

## Solution
Implemented Unicode NFD normalization to strip diacritical marks from both the search query and searchable text, enabling accent-insensitive matching.

## Changes
- Created new textNormalizer.js utility with normalizeText() function
- Updated autoComplete.js to use the normalizer for search matching
- Added 9 comprehensive unit tests covering Portuguese, Spanish, French, and German accents

## Technical Details
The normalizeText() function:
1. Converts text to lowercase
2. Applies NFD (Canonical Decomposition) normalization
3. Removes Unicode combining diacritical marks (U+0300 to U+036F)

## Testing
- All 127 unit tests pass
- Tested with various accented characters from multiple languages

Fixes #356

---
*Third contribution to this project!*