### PR TITLE
fix: Add Cross-Origin-Opener-Policy header for Google Sign-In

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -25,6 +25,11 @@ Object.entries(featureToggles).forEach(function ([key, value]) {
 })
 
 module.exports = merge(common, {
+  devServer: {
+    headers: {
+      'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+    },
+  },
   mode: 'development',
   entry: { main: main },
   performance: {
@@ -72,3 +77,4 @@ module.exports = merge(common, {
   ],
   devtool: 'source-map',
 })
+


### PR DESCRIPTION
## Summary
Adds the \Cross-Origin-Opener-Policy: same-origin-allow-popups\ header to the webpack dev server configuration to fix Google OneTap Sign-In popup being blocked.

## Changes
- Added \devServer.headers\ configuration to \webpack.dev.js\
- Sets COOP header as suggested by maintainer in issue comments

## Testing
- Start dev server with \
pm run dev\
- Navigate to radar with a private Google Sheet URL
- Google OneTap popup should now appear without being blocked

Fixes #346