### PR TITLE
Fix: Docker build failure - Unable to locate package nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
 FROM nginx:1.23.0
 
+# Update apt and install required packages
 RUN apt-get update && apt-get upgrade -y
 
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt-get install -y nodejs
+# Install Node.js using NodeSource - run apt-get update after setup script
+# The setup script adds the NodeSource repository but apt cache may be stale
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get update \
+    && apt-get install -y nodejs
 
-RUN                                                                       \
-  apt-get install -y                                                      \
-  libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3    \
-  libxss1 libasound2 libxtst6 xauth xvfb g++ make
+# Install dependencies for Cypress and build tools
+RUN apt-get install -y \
+    libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 \
+    libxss1 libasound2 libxtst6 xauth xvfb g++ make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src/build-your-own-radar
 COPY package.json ./
@@ -17,7 +23,7 @@ RUN npm ci
 
 COPY . ./
 
-# Override parent node image's entrypoint script (/usr/local/bin/docker-entrypoint.sh),
+# Override parent node image entrypoint script (/usr/local/bin/docker-entrypoint.sh),
 # which tries to run CMD as a node command
 ENTRYPOINT []
 CMD ["./build_and_start_nginx.sh"]


### PR DESCRIPTION
## Issue
Fixes #333

## Problem
Docker build fails with:
\\\
E: Unable to locate package nodejs
\\\

This happens because the NodeSource repository setup and the \pt-get install nodejs\ are in separate RUN commands. The package index from the first RUN layer is not available in subsequent layers.

## Solution
Combined the NodeSource setup, apt-get update, and apt-get install nodejs into a single RUN command:

\\\dockerfile
RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
    apt-get update && \
    apt-get install -y nodejs
\\\

## Root Cause
Docker layers are independent. When you run \pt-get update\ in one layer and \pt-get install\ in another, the package cache from the first layer is not guaranteed to be available or valid in the second layer.

## Testing
This fix follows standard Docker best practices for package installation.